### PR TITLE
HP-1966: fixed "jquery.js:1468 Uncaught Error: Syntax error, unrecognized expression: .editable[data-pk=][data-name=note]" error which prevents a Playwright test from executing

### DIFF
--- a/src/traits/XEditableTrait.php
+++ b/src/traits/XEditableTrait.php
@@ -64,8 +64,14 @@ trait XEditableTrait
         if ($this->pluginOptions['url']) {
             $this->pluginOptions['url'] = Url::to($this->pluginOptions['url']);
         }
-        $selector = ArrayHelper::remove($this->pluginOptions, 'selector', ".editable[data-pk={$data['model']->primaryKey}][data-name={$data['attribute']}]");
-        Yii::$app->view->registerJs('$("' . $selector . '").editable(' . Json::htmlEncode($this->pluginOptions) . ');');
+        if ($data['model']->primaryKey) {
+            $selector = ArrayHelper::remove(
+                $this->pluginOptions,
+                'selector',
+                ".editable[data-pk={$data['model']->primaryKey}][data-name={$data['attribute']}]",
+            );
+            Yii::$app->view->registerJs('$("' . $selector . '").editable(' . Json::htmlEncode($this->pluginOptions) . ');');
+        }
     }
 
     public function prepareValue($data)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding a conditional check to ensure the primary key exists before setting the selector for editable elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->